### PR TITLE
🐛 crypto hash 的计算采用 Buffer 方式，使结果和标准 md5 计算一致。

### DIFF
--- a/version_generator.js
+++ b/version_generator.js
@@ -68,7 +68,7 @@ function readDir (dir, obj) {
         else if (stat.isFile()) {
             // Size in Bytes
             size = stat['size'];
-            md5 = crypto.createHash('md5').update(fs.readFileSync(subpath, 'binary')).digest('hex');
+            md5 = crypto.createHash('md5').update(fs.readFileSync(subpath)).digest('hex');
             compressed = path.extname(subpath).toLowerCase() === '.zip';
 
             relative = path.relative(src, subpath);


### PR DESCRIPTION
the solution for #15  