### PR TITLE
删除使用 fs.readFileSync 时的第二个参数

### DIFF
--- a/version_generator.js
+++ b/version_generator.js
@@ -68,7 +68,7 @@ function readDir (dir, obj) {
         else if (stat.isFile()) {
             // Size in Bytes
             size = stat['size'];
-            md5 = crypto.createHash('md5').update(fs.readFileSync(subpath, 'binary')).digest('hex');
+            md5 = crypto.createHash('md5').update(fs.readFileSync(subpath)).digest('hex');
             compressed = path.extname(subpath).toLowerCase() === '.zip';
 
             relative = path.relative(src, subpath);


### PR DESCRIPTION
传入第二个参数可能导致生成的 md5 值有问题.

运行环境 windows10, NodeJs 版本 v10.13.0.